### PR TITLE
MSM:SPS:Register SPS IRQ with IRQF_NO_SUSPEND flag

### DIFF
--- a/drivers/platform/msm/sps/sps_bam.c
+++ b/drivers/platform/msm/sps/sps_bam.c
@@ -223,7 +223,8 @@ int sps_bam_enable(struct sps_bam *dev)
 		if (dev->props.irq > 0)
 			result = request_irq(dev->props.irq,
 				    (irq_handler_t) bam_isr,
-				    IRQF_TRIGGER_HIGH, "sps", dev);
+				    IRQF_TRIGGER_HIGH | IRQF_NO_SUSPEND, 
+				    "sps", dev);
 
 		if (result) {
 			SPS_ERR("sps:Failed to enable BAM 0x%x IRQ %d\n",

--- a/drivers/video/msm/mdss/mdss_mdp_trace.h
+++ b/drivers/video/msm/mdss/mdss_mdp_trace.h
@@ -17,7 +17,7 @@
 #undef TRACE_SYSTEM
 #define TRACE_SYSTEM mdss
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/video/msm/mdss
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE mdss_mdp_trace
 


### PR DESCRIPTION
This is a wakeup-enabled interrupt, so IRQF_NO_SUSPEND
should be used in order to avoid delays during system
suspend/resume and unbalanced IRQ enable.

<4>[60874.026643] ------------[ cut here ]------------
<4>[60874.026670] WARNING: at /home/nubia/built/AutoRelease_1.20_nubia/NX507J_UI35_11K373_20151221211100/app/kernel/kernel/irq/manage.c:428 resume_irqs+0x6c/0x84()
<4>[60874.026686] Unbalanced enable for IRQ 61
<6>[60874.026694] Modules linked in: wlan(O) texfat(PO) [last unloaded: wlan]
<6>[60874.026744] [<c010c000>](unwind_backtrace+0x0/0x11c) from [<c0194144>](warn_slowpath_common+0x4c/0x64)
<6>[60874.026770] [<c0194144>](warn_slowpath_common+0x4c/0x64) from [<c0194188>](warn_slowpath_fmt+0x2c/0x3c)
<6>[60874.026794] [<c0194188>](warn_slowpath_fmt+0x2c/0x3c) from [<c01f6f40>](resume_irqs+0x6c/0x84)
<6>[60874.026829] [<c01f6f40>](resume_irqs+0x6c/0x84) from [<c047c670>](dpm_resume_start+0xc/0x18)
<6>[60874.026865] [<c047c670>](dpm_resume_start+0xc/0x18) from [<c01ce224>](suspend_devices_and_enter+0x148/0x310)
<6>[60874.026894] [<c01ce224>](suspend_devices_and_enter+0x148/0x310) from [<c01ce4e8>](pm_suspend+0xfc/0x224)
<6>[60874.026921] [<c01ce4e8>](pm_suspend+0xfc/0x224) from [<c01cd6d8>](state_store+0x40/0x68)
<6>[60874.026952] [<c01cd6d8>](state_store+0x40/0x68) from [<c038379c>](kobj_attr_store+0x14/0x20)
<6>[60874.026987] [<c038379c>](kobj_attr_store+0x14/0x20) from [<c02a1d84>](sysfs_write_file+0x104/0x148)
<6>[60874.027018] [<c02a1d84>](sysfs_write_file+0x104/0x148) from [<c0252f90>](vfs_write+0xa8/0x138)
<6>[60874.027043] [<c0252f90>](vfs_write+0xa8/0x138) from [<c0253244>](sys_write+0x34/0x68)
<6>[60874.027071] [<c0253244>](sys_write+0x34/0x68) from [<c0105fc0>](ret_fast_syscall+0x0/0x30)
<4>[60874.027086] ---[ end trace 8abe76fe156d34e1 ]---

Referenced https://github.com/CyanogenMod/android_kernel_oneplus_msm8974/commit/4dd7d39b85ae88b58ddacd7391d6fcde67865f95
